### PR TITLE
[CLEAN UP] Refactoring auth routes

### DIFF
--- a/src/Routes/index.jsx
+++ b/src/Routes/index.jsx
@@ -7,37 +7,47 @@ import { SignIn } from "../Pages/SignIn";
 import { Notfound } from "../Pages/NotFound";
 import { useContext } from "react";
 import { ShoppingCartContext } from "../Context";
+import { Navigate } from "react-router-dom";
 
 function AppRoutes() {
   const context = useContext(ShoppingCartContext);
 
+
+  const isLoggedOff = context.signOut
+
+
   return useRoutes([
-    { path: "/", element: context.signOut ? <SignIn /> : <Home /> },
-    { path: "/men-clothing", element: context.signOut ? <SignIn /> : <Home /> },
+    { path: "/login", element: isLoggedOff ? <SignIn /> : < Navigate to='/' /> },
     {
-      path: "/women-clothing",
-      element: context.signOut ? <SignIn /> : <Home />,
-    },
-    { path: "/electronics", element: context.signOut ? <SignIn /> : <Home /> },
-    { path: "/jewelery", element: context.signOut ? <SignIn /> : <Home /> },
-    { path: "/my-order", element: context.signOut ? <SignIn /> : <MyOrder /> },
-    {
-      path: "/my-orders",
-      element: context.signOut ? <SignIn /> : <MyOrders />,
-    },
-    {
-      path: "/my-orders/last",
-      element: context.signOut ? <SignIn /> : <MyOrder />,
-    },
-    {
-      path: "/my-orders/:id",
-      element: context.signOut ? <SignIn /> : <MyOrder />,
-    },
-    {
-      path: "/my-account",
-      element: context.signOut ? <SignIn /> : <MyAccount />,
-    },
-    { path: "/*", element: context.signOut ? <SignIn /> : <Notfound /> },
+      path: '/', element: isLoggedOff ? < Navigate to='/login' /> : <Home />, children: [
+        { path: "/men-clothing", element: <Home /> },
+        {
+          path: "/women-clothing",
+          element: <Home />,
+        },
+        { path: "/electronics", element: <Home /> },
+        { path: "/jewelery", element: <Home /> },
+        { path: "/my-order", element: <MyOrder /> },
+        {
+          path: "/my-orders",
+          element: <MyOrders />,
+        },
+        {
+          path: "/my-orders/last",
+          element: <MyOrder />,
+        },
+        {
+          path: "/my-orders/:id",
+          element: <MyOrder />,
+        },
+        {
+          path: "/my-account",
+          element: <MyAccount />,
+        },
+        { path: "/*", element: <Notfound /> },
+      ]
+    }
+
   ]);
 }
 


### PR DESCRIPTION
Repetition is bad. If we repeat code more than 3 times we should extract it to simplify the code, make it tidier and to avoid bugs.
In this case instead of extracting the code, I refactored it so we don't need to repeat.\
I added
- A new route, `/login` that is public. If the user is logged in it redirects to `/`
- A new group of routes under `/` that, if the user is logged of, it redirects to `/login` otherwise it renders the child routes